### PR TITLE
Phase filter didn't filter properly

### DIFF
--- a/src/wikiparse/core.clj
+++ b/src/wikiparse/core.clj
@@ -133,7 +133,7 @@
 
 (defn phase-filter
   [phase]
-  (cond (= :simultaneous) identity
+  (cond (= :simultaneous phase) identity
         (= :redirects phase) :redirect
         (= :full phase) (comp nil? :redirect)
         :else nil))


### PR DESCRIPTION
clojure.core/= returns true always when passed a single argument, no
matter the argument, including nil and false, so the conditional in
phase-filter always returns the identity function.

This patch fixes that.
